### PR TITLE
Add trivial Makefile and fix C++ warnings/errors on macOS 10.14.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+gfslogger

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+default: gfslogger
+
+gfslogger: gfslogger.c
+	cc -o $@ $<
+
+clean:
+	rm -vf gfslogger


### PR DESCRIPTION
This fixes a few warnings and errors that crop up when you compile gfslogger.c with 'g++ -o gfslogger gfslogger.c'.